### PR TITLE
feat: migrate combat UI to modern action-RPG layout

### DIFF
--- a/game.html
+++ b/game.html
@@ -18,7 +18,7 @@
   #wd-wrapper h1, #wd-wrapper h2, #wd-wrapper h3, #wd-wrapper h4, #wd-wrapper .btn-main-text, #wd-wrapper .tab-btn { font-family: 'Cinzel', serif; font-weight: 700; letter-spacing: 1px; }
   #wd-wrapper ::-webkit-scrollbar { width: 8px; } #wd-wrapper ::-webkit-scrollbar-track { background: #000; border-left: 1px solid var(--border); } #wd-wrapper ::-webkit-scrollbar-thumb { background: var(--border-light); border-radius: 2px; } #wd-wrapper ::-webkit-scrollbar-thumb:hover { background: var(--accent); }
   #wd-app { display: flex; flex-direction: column; width: 100%; height: 100%; box-shadow: inset 0 0 100px #000; position: relative; }
-  #wd-sidebar-left { position: absolute; top: 12px; left: 12px; width: min(380px, calc(100% - 24px)); max-height: 220px; overflow-y: auto; background: linear-gradient(to right, rgba(10,10,12,0.95), rgba(17,16,21,0.9)); border: 2px ridge var(--border); border-radius: 6px; display: flex; flex-direction: column; padding: 12px 14px; z-index: 20; box-shadow: 0 10px 20px rgba(0,0,0,0.8); }
+  #wd-sidebar-left { position: absolute; top: 12px; left: 12px; width: min(380px, calc(100% - 24px)); max-height: min(46vh, 420px); overflow-y: auto; background: linear-gradient(to right, rgba(10,10,12,0.95), rgba(17,16,21,0.9)); border: 2px ridge var(--border); border-radius: 6px; display: flex; flex-direction: column; padding: 12px 14px; z-index: 24; box-shadow: 0 10px 20px rgba(0,0,0,0.8); }
   
   .wd-hero-header { display: flex; align-items: center; gap: 15px; margin-bottom: 25px; padding-bottom: 15px; border-bottom: 1px solid var(--border); }
   .wd-hero-avatar { width: 65px; height: 65px; border-radius: 8px; background: #000; border: 2px solid var(--accent); display: grid; place-items: center; font-size: 2.2rem; box-shadow: inset 0 0 15px rgba(212, 175, 55, 0.2), 0 0 10px rgba(0,0,0,0.8); text-shadow: 0 0 10px rgba(255,255,255,0.3); }
@@ -182,9 +182,6 @@
   .wd-hud-panel.enemy { margin-left: auto; }
   .wd-hud-name { font-family: 'Cinzel', serif; font-size: 0.75rem; color: var(--text-muted); letter-spacing: 1px; margin-bottom: 6px; text-transform: uppercase; }
   .wd-hud-panel.enemy .wd-hud-name { text-align: right; }
-  #wd-sidebar-left .wd-stat-bar-container:nth-of-type(3) { display: none; }
-  #wd-sidebar-left .wd-quick-stats, #wd-sidebar-left #wd-status-effects, #wd-sidebar-left > div[style*="margin-top:auto"] { display: none; }
-
   @media (max-width: 900px) {
     #wd-wrapper { height: auto; min-height: 800px; }
     #wd-sidebar-left, #wd-sidebar-right { position: static; width: 100%; max-height: none; border-radius: 0; }


### PR DESCRIPTION
### Motivation
- Replace the legacy 3-column HUD with an arena-centric Action-RPG layout so the combat arena is the visual focus and actions sit in a fixed bottom bar.  
- Surface core combat info (player/enemy HP & MP) into an always-visible top HUD overlay to match modern ARPG conventions.  
- Keep runtime correctness by ensuring HUD values remain synchronized during combat animations/turns and preserve compatibility with older save payloads.

### Description
- Reworked shell and layout CSS: added `body` reset, changed `#wd-app` to a column layout, repositioned sidebars (`#wd-sidebar-left`, `#wd-sidebar-right`) as floating panels, increased arena space via `#wd-visual-arena { flex: 0 0 70% }`, and anchored the action area with `#wd-action-panel` fixed to the bottom of the viewport.  
- Inserted a top combat HUD HTML block (`#wd-combat-hud`) with player panel (left) and enemy panel (right) showing HP/MP and name, plus CSS `.wd-hud-panel` and responsive adjustments.  
- Added `updateEnemyHUD()` and wired it into the existing flows by calling it from `updateHUD()`, `showCombatStage()`, and `visualDamage()` so enemy HUD bars remain in sync with combat changes.  
- Introduced enemy mana fields (`m`, `maxM`) at spawn and implemented simple mana dynamics: player attacks and enemy abilities adjust `state.enemy.m`, enemy attacks can regenerate enemy mana, and save migration now backfills `gameState.enemy.maxM`/`m` for older saves in `migrateSave()`.

### Testing
- Validated embedded game script by running a Node-based parse/execute check (`new Function(...)` on the `<script>` content), which completed successfully.  
- Verified presence of new layout and sync identifiers using `rg` for strings such as `wd-combat-hud`, `updateEnemyHUD`, and `m: 100, maxM: 100`, which returned matches.  
- Performed a syntax sanity check on the modified `game.html` JS (via the same `node` invocation) with no syntax errors reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7d53647cc8323b70df838db8e1d1f)